### PR TITLE
Fix: Configure base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig(({ mode }) => ({
     mode === 'development' &&
     componentTagger(),
   ].filter(Boolean),
+  base: '/croissanteria-bucuresti-website/', // Set base path for GitHub Pages
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
Updated vite.config.ts to include the correct `base` path ('/croissanteria-bucuresti-website/') to ensure assets are loaded correctly when deployed to GitHub Pages.

This should resolve issues with the site appearing as a blank page due to incorrect asset URLs.