### PR TITLE
Fix: Explicitly set build.outDir and reiterate GH Pages setup

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,9 @@ export default defineConfig(({ mode }) => ({
     componentTagger(),
   ].filter(Boolean),
   base: '/croissanteria-bucuresti-website/', // Set base path for GitHub Pages
+  build: {
+    outDir: 'dist', // Explicitly set output directory (default is 'dist')
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
- Explicitly set `build.outDir` to `dist` in `vite.config.ts` for clarity, though this is the default Vite behavior.
- This change supports the necessary GitHub Pages configuration where the deployment source folder must be set to `/dist` when using the `main` branch (or equivalent) for deployment.