### PR TITLE
Fix: Remove dist from .gitignore for GitHub Pages deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-dist
+# dist # Removed to allow dist folder to be committed for GitHub Pages
 dist-ssr
 *.local
 


### PR DESCRIPTION
To allow the build output folder (`dist/`) to be committed and pushed to the repository, it has been removed from .gitignore.

This is a necessary step for deploying to GitHub Pages when the `dist` folder from the deployment branch is used as the source.